### PR TITLE
Fix negative array size in AlignAction

### DIFF
--- a/src/main/java/aligncarets/AlignAction.java
+++ b/src/main/java/aligncarets/AlignAction.java
@@ -29,6 +29,9 @@ public class AlignAction extends AnAction {
         WriteCommandAction.runWriteCommandAction(e.getProject(), () -> {
             for (Caret caret : carets) {
                 int pad = maxColumn - caret.getLogicalPosition().column;
+                if (pad <= 0) {
+                    continue;
+                }
                 int offset = caret.getOffset();
                 document.insertString(offset, repeat(' ', pad));
                 caret.moveToOffset(offset + pad);
@@ -37,6 +40,9 @@ public class AlignAction extends AnAction {
     }
 
     private String repeat(char ch, int times) {
+        if (times <= 0) {
+            return "";
+        }
         char[] arr = new char[times];
         Arrays.fill(arr, ch);
         return new String(arr);


### PR DESCRIPTION
## Summary
- avoid inserting spaces when padding value is negative
- handle non-positive counts in `repeat`

## Testing
- `gradle test --no-daemon --info`

------
https://chatgpt.com/codex/tasks/task_e_6841519add308330abe225ada1e5eba0