### PR TITLE
Fix align action update thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'align-carets'
-version = '1.0.0'
+version = '1.0.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/aligncarets/AlignAction.java
+++ b/src/main/java/aligncarets/AlignAction.java
@@ -3,6 +3,7 @@ package aligncarets;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Document;
@@ -18,6 +19,13 @@ public class AlignAction extends AnAction {
         Project project = e.getProject();
         Editor editor = e.getData(CommonDataKeys.EDITOR);
         e.getPresentation().setVisible(project != null && editor != null && editor.getCaretModel().getCaretCount() > 1);
+    }
+
+    @Override
+    public ActionUpdateThread getActionUpdateThread() {
+        // The update method only queries editor state, which is inexpensive, so
+        // it can safely run on a background thread.
+        return ActionUpdateThread.BGT;
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>align-carets</id>
     <name>align-carets</name>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <vendor email="chris.ch.cheung@gmail.com">Chris Cheung</vendor>
 
     <description><![CDATA[


### PR DESCRIPTION
## Summary
- prevent deprecation errors in 2024.1 by overriding `getActionUpdateThread`
- bump plugin version to 1.0.1

## Testing
- `gradle wrapper --gradle-version 8.14 --distribution-type bin`
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684150fa78808330b015390272aea2fa