### PR TITLE
Update plugin publish instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@ it works by inserting spaces to match the right most caret
 
 ### Publishing
 
-The Gradle build uses the `publishPlugin` task. Authentication details are
-read from the environment variables `PLUGIN_USERNAME` and `PLUGIN_PASSWORD`.
-In GitHub Actions, add these as repository secrets and they will be available
-when the plugin is published.
+To publish the plugin, run `./gradlew publishPlugin` with the `PUBLISH_TOKEN` environment variable set to a JetBrains Marketplace token. In GitHub Actions, add this variable as a repository secret so that it is available during the publish step.
 
 ### Gradle wrapper
 

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,22 @@
+# Agent Notes
+
+This repository uses Gradle for builds. Helpful commands:
+
+- Generate the wrapper JAR if it is missing:
+  ```bash
+  gradle wrapper --gradle-version 8.14 --distribution-type bin
+  ```
+- Run tests:
+  ```bash
+  ./gradlew test --no-daemon
+  ```
+- Build the plugin locally:
+  ```bash
+  ./gradlew buildPlugin
+  ```
+- Publish the plugin to the JetBrains Marketplace:
+  ```bash
+  PUBLISH_TOKEN=<token> ./gradlew publishPlugin
+  ```
+  `PUBLISH_TOKEN` is a token from the JetBrains Marketplace. Add it as a GitHub
+  Actions secret for CI publishing.


### PR DESCRIPTION
## Summary
- clarify `PUBLISH_TOKEN` usage for publishing the plugin
- remove old env variable references
- add an `agent.md` helper file for future tasks

## Testing
- `gradle wrapper --gradle-version 8.14 --distribution-type bin`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68416eb0c5a08330a1039ad79ebd7fb7