### PR TITLE
Add manual version bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,61 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: "Version part to increment"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Generate wrapper jar
+        run: gradle wrapper --gradle-version 8.14 --distribution-type bin
+
+      - name: Bump version
+        run: ./scripts/bump-version.sh ${{ github.event.inputs.level }}
+
+      - name: Get new version
+        id: version
+        run: |
+          new=$(grep "^version =" build.gradle | sed -E "s/.*'(.*)'/\1/")
+          echo "version=$new" >> "$GITHUB_OUTPUT"
+
+      - name: Collect commit titles
+        id: titles
+        run: |
+          last=$(git log -1 --format=%H -- build.gradle)
+          log=$(git log --format='%s' ${last}..HEAD | sed 's/^/- /')
+          echo "log<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$log" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: |
+            chore: bump version to ${{ steps.version.outputs.version }}
+            
+            ${{ steps.titles.outputs.log }}
+          title: "Bump version to ${{ steps.version.outputs.version }}"
+          body: |
+            Bumps the plugin version to `${{ steps.version.outputs.version }}`.
+
+            ## Changes since last release
+            ${{ steps.titles.outputs.log }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Generate wrapper jar
+        run: gradle wrapper --gradle-version 8.14 --distribution-type bin
+      - name: Build plugin
+        run: ./gradlew buildPlugin --no-daemon
+      - name: Publish plugin
+        run: ./gradlew publishPlugin --no-daemon
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@ align-carets plugin for intellij
 
 it works by inserting spaces to match the right most caret
 
+### Version bumps
+
+Use the **Bump Version** workflow in GitHub Actions to create a pull request
+that increments the plugin version. The workflow accepts a `patch`, `minor` or
+`major` level and lists recent commit titles in the PR description.
+
 ### Publishing
 
 The Gradle build uses the `publishPlugin` task. Authentication details are
-read from the environment variables `PLUGIN_USERNAME` and `PLUGIN_PASSWORD`.
-In GitHub Actions, add these as repository secrets and they will be available
-when the plugin is published.
+read from the environment variable `PUBLISH_TOKEN`. In GitHub Actions add this
+secret so the publish workflow can deploy the plugin once a version bump PR is
+merged.
 
 ### Gradle wrapper
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LEVEL=${1:-patch}
+
+BUILD_FILE="build.gradle"
+XML_FILE="src/main/resources/META-INF/plugin.xml"
+
+current=$(grep "^version =" "$BUILD_FILE" | sed -E "s/.*'(.*)'/\1/")
+IFS='.' read -r major minor patch <<< "$current"
+
+case "$LEVEL" in
+  patch)
+    patch=$((patch + 1))
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  *)
+    echo "Unknown level: $LEVEL" >&2
+    exit 1
+    ;;
+esac
+
+new_version="$major.$minor.$patch"
+
+sed -i -E "s/version = '.+'/version = '$new_version'/" "$BUILD_FILE"
+sed -i -E "s#<version>[^<]+</version>#<version>$new_version</version>#" "$XML_FILE"
+
+echo "Bumped version to $new_version"


### PR DESCRIPTION
## Summary
- add workflow to manually bump plugin version and open a PR
- remove auto version bump from publish workflow
- document manual bump process and update publish instructions

## Testing
- `gradle wrapper --gradle-version 8.14 --distribution-type bin`
- `./gradlew build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68416c1fb4508330a48e2c84b48399f6