### PR TITLE
Remove wrapper download instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Generate wrapper jar
-        run: gradle wrapper --gradle-version 8.14 --distribution-type bin
       - name: Build plugin
         run: ./gradlew build --no-daemon
       - name: Upload plugin artifact

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -25,8 +25,6 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Generate wrapper jar
-        run: gradle wrapper --gradle-version 8.14 --distribution-type bin
 
       - name: Bump version
         run: ./scripts/bump-version.sh ${{ github.event.inputs.level }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Generate wrapper jar
-        run: gradle wrapper --gradle-version 8.14 --distribution-type bin
       - name: Build plugin
         run: ./gradlew buildPlugin --no-daemon
       - name: Publish plugin

--- a/README.md
+++ b/README.md
@@ -13,17 +13,6 @@ that increments the plugin version. The workflow accepts a `patch`, `minor` or
 
 To publish the plugin, run `./gradlew publishPlugin` with the `PUBLISH_TOKEN` environment variable set to a JetBrains Marketplace token. In GitHub Actions, add this variable as a repository secret so that it is available during the publish step.
 
-### Gradle wrapper
-
-This repository does not include the `gradle-wrapper.jar` file. To generate it,
-run:
-
-```bash
-gradle wrapper --gradle-version 8.14 --distribution-type bin
-```
-
-This command downloads the required wrapper files so `./gradlew` works.
-
 ### Local installation
 
 After building the project with `./gradlew buildPlugin`, the plugin archive is

--- a/agent.md
+++ b/agent.md
@@ -2,10 +2,6 @@
 
 This repository uses Gradle for builds. Helpful commands:
 
-- Generate the wrapper JAR if it is missing:
-  ```bash
-  gradle wrapper --gradle-version 8.14 --distribution-type bin
-  ```
 - Run tests:
   ```bash
   ./gradlew test --no-daemon


### PR DESCRIPTION
## Summary
- remove Gradle wrapper section from README so it's clear `./gradlew` works out of the box

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68418225f7748330af9bd833086f13ac