### PR TITLE
Fix bump workflow commit log

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- fetch full Git history in bump workflow so commit titles are collected

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6841a06aef4c833098dafbd1af9a432e