### PR TITLE
Set minimum IntelliJ version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,13 @@ java {
 }
 
 intellij {
-    version.set('2024.1')
+    version.set('2022.3')
     pluginName.set('align-carets')
     updateSinceUntilBuild.set(false)
 }
 
 patchPluginXml {
-    sinceBuild.set('241')
+    sinceBuild.set('223')
 }
 
 publishPlugin {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="241"/>
+    <idea-version since-build="223"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->


### PR DESCRIPTION
## Summary
- set `intellij.version` to 2022.3
- set `sinceBuild` to 223 in build configuration and plugin descriptor

## Testing
- `./gradlew test --no-daemon` *(fails: Network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6841cb875dd88330bf8b4c5b668920a3